### PR TITLE
Clang fixes

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -304,8 +304,14 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
     }
 
   case llvm::Triple::m680x0:
-  case llvm::Triple::m68k:
-    return new M680x0TargetInfo(Triple, Opts);
+    switch (os) {
+    case llvm::Triple::Linux:
+      return new LinuxTargetInfo<M680x0TargetInfo>(Triple, Opts);
+    case llvm::Triple::NetBSD:
+      return new NetBSDTargetInfo<M680x0TargetInfo>(Triple, Opts);
+    default:
+      return new M680x0TargetInfo(Triple, Opts);
+    }
 
   case llvm::Triple::le32:
     switch (os) {

--- a/clang/lib/Driver/CMakeLists.txt
+++ b/clang/lib/Driver/CMakeLists.txt
@@ -26,6 +26,7 @@ add_clang_library(clangDriver
   ToolChain.cpp
   ToolChains/Arch/AArch64.cpp
   ToolChains/Arch/ARM.cpp
+  ToolChains/Arch/M680x0.cpp
   ToolChains/Arch/Mips.cpp
   ToolChains/Arch/PPC.cpp
   ToolChains/Arch/RISCV.cpp

--- a/clang/lib/Driver/ToolChains/Arch/M680x0.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/M680x0.cpp
@@ -1,0 +1,88 @@
+//===--- M680x0.cpp - M680x0 Helpers for Tools ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "M680x0.h"
+#include "ToolChains/CommonArgs.h"
+#include "clang/Driver/Driver.h"
+#include "clang/Driver/DriverDiagnostic.h"
+#include "clang/Driver/Options.h"
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/Option/ArgList.h"
+#include "llvm/Support/Host.h"
+
+using namespace clang::driver;
+using namespace clang::driver::tools;
+using namespace clang;
+using namespace llvm::opt;
+
+/// getM680x0TargetCPU - Get the (LLVM) name of the 68000 cpu we are targeting.
+std::string m680x0::getM680x0TargetCPU(const ArgList &Args) {
+  if (Arg *A = Args.getLastArg(clang::driver::options::OPT_mcpu_EQ)) {
+    StringRef CPUName = A->getValue();
+
+    if (CPUName == "native") {
+      std::string CPU = std::string(llvm::sys::getHostCPUName());
+      if (!CPU.empty() && CPU != "generic")
+        return CPU;
+      else
+        return "";
+    }
+
+    return llvm::StringSwitch<const char *>(CPUName)
+        .Case("common", "generic")
+        .Case("68000", "68000")
+        .Case("68010", "68000")
+        .Case("68020", "68000")
+        .Case("68030", "68000")
+        .Case("68040", "68000")
+        .Case("68060", "68000")
+        .Default("");
+  }
+
+  return "";
+}
+
+const char *m680x0::getM680x0AsmModeForCPU(StringRef Name) {
+  return llvm::StringSwitch<const char *>(Name)
+        .Case("68000", "-m68000")
+        .Case("68010", "-m60010")
+        .Case("68020", "-m68020")
+        .Case("68030", "-m68030")
+        .Case("68040", "-m68040")
+        .Case("68060", "-m68060")
+        .Default("-many");
+}
+
+void m680x0::getM680x0TargetFeatures(const Driver &D, const llvm::Triple &Triple,
+                               const ArgList &Args,
+                               std::vector<StringRef> &Features) {
+
+  m680x0::FloatABI FloatABI = m680x0::getM680x0FloatABI(D, Args);
+  if (FloatABI == m680x0::FloatABI::Soft)
+    Features.push_back("-hard-float");
+
+}
+
+m680x0::FloatABI m680x0::getM680x0FloatABI(const Driver &D, const ArgList &Args) {
+  m680x0::FloatABI ABI = m680x0::FloatABI::Invalid;
+  if (Arg *A =
+          Args.getLastArg(options::OPT_msoft_float, options::OPT_mhard_float)) {
+
+    if (A->getOption().matches(options::OPT_msoft_float))
+      ABI = m680x0::FloatABI::Soft;
+    else if (A->getOption().matches(options::OPT_mhard_float))
+      ABI = m680x0::FloatABI::Hard;
+  }
+
+  // If unspecified, choose the default based on the platform.
+  if (ABI == m680x0::FloatABI::Invalid) {
+    ABI = m680x0::FloatABI::Hard;
+  }
+
+  return ABI;
+}

--- a/clang/lib/Driver/ToolChains/Arch/M680x0.h
+++ b/clang/lib/Driver/ToolChains/Arch/M680x0.h
@@ -1,0 +1,43 @@
+//===--- M680x0.h - M680x0-specific Tool Helpers ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_ARCH_M680X0_H
+#define LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_ARCH_M680X0_H
+
+#include "clang/Driver/Driver.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Option/Option.h"
+#include <string>
+#include <vector>
+
+namespace clang {
+namespace driver {
+namespace tools {
+namespace m680x0 {
+
+enum class FloatABI {
+  Invalid,
+  Soft,
+  Hard,
+};
+
+FloatABI getM680x0FloatABI(const Driver &D, const llvm::opt::ArgList &Args);
+
+std::string getM680x0TargetCPU(const llvm::opt::ArgList &Args);
+const char *getM680x0AsmModeForCPU(StringRef Name);
+
+void getM680x0TargetFeatures(const Driver &D, const llvm::Triple &Triple,
+                          const llvm::opt::ArgList &Args,
+                          std::vector<llvm::StringRef> &Features);
+
+} // end namespace m680x0
+} // end namespace target
+} // end namespace driver
+} // end namespace clang
+
+#endif // LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_ARCH_M680X0_H

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -2042,6 +2042,10 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
       "i686-linux-android",   "i386-gnu",              "i486-gnu",
       "i586-gnu",             "i686-gnu"};
 
+  static const char *const M680x0LibDirs[] = {"/lib"};
+  static const char *const M680x0Triples[] = {
+       "m68k-linux-gnu", "m68k-unknown-linux-gnu", "m68k-suse-linux"};
+
   static const char *const MIPSLibDirs[] = {"/lib"};
   static const char *const MIPSTriples[] = {
       "mips-linux-gnu", "mips-mti-linux", "mips-mti-linux-gnu",
@@ -2274,6 +2278,10 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
       BiarchLibDirs.append(begin(X86_64LibDirs), end(X86_64LibDirs));
       BiarchTripleAliases.append(begin(X86_64Triples), end(X86_64Triples));
     }
+    break;
+  case llvm::Triple::m680x0:
+    LibDirs.append(begin(M680x0LibDirs), end(M680x0LibDirs));
+    TripleAliases.append(begin(M680x0Triples), end(M680x0Triples));
     break;
   case llvm::Triple::mips:
     LibDirs.append(begin(MIPSLibDirs), end(MIPSLibDirs));

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -270,6 +270,8 @@ static const char *getLDMOption(const llvm::Triple &T, const ArgList &Args) {
   case llvm::Triple::armeb:
   case llvm::Triple::thumbeb:
     return isArmBigEndian(T, Args) ? "armelfb_linux_eabi" : "armelf_linux_eabi";
+  case llvm::Triple::m680x0:
+    return "m68kelf";
   case llvm::Triple::ppc:
     return "elf32ppclinux";
   case llvm::Triple::ppc64:

--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -102,6 +102,12 @@ std::string Linux::getMultiarchTriple(const Driver &D,
     if (D.getVFS().exists(SysRoot + "/lib/aarch64_be-linux-gnu"))
       return "aarch64_be-linux-gnu";
     break;
+
+  case llvm::Triple::m680x0:
+    if (D.getVFS().exists(SysRoot + "/lib/m68k-linux-gnu"))
+      return "m68k-linux-gnu";
+    break;
+
   case llvm::Triple::mips: {
     std::string MT = IsMipsR6 ? "mipsisa32r6-linux-gnu" : "mips-linux-gnu";
     if (D.getVFS().exists(SysRoot + "/lib/" + MT))
@@ -468,6 +474,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
     Loader = HF ? "ld-linux-armhf.so.3" : "ld-linux.so.3";
     break;
   }
+  case llvm::Triple::m680x0:
+    LibDir = "lib";
+    Loader = "ld.so.1";
+    break;
   case llvm::Triple::mips:
   case llvm::Triple::mipsel:
   case llvm::Triple::mips64:
@@ -610,6 +620,8 @@ void Linux::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
       "/usr/include/armeb-linux-gnueabi"};
   const StringRef ARMEBHFMultiarchIncludeDirs[] = {
       "/usr/include/armeb-linux-gnueabihf"};
+  const StringRef M680x0MultiarchIncludeDirs[] = {
+      "/usr/include/m68k-linux-gnu"};
   const StringRef MIPSMultiarchIncludeDirs[] = {"/usr/include/mips-linux-gnu"};
   const StringRef MIPSELMultiarchIncludeDirs[] = {
       "/usr/include/mipsel-linux-gnu"};
@@ -671,6 +683,9 @@ void Linux::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
       MultiarchIncludeDirs = ARMEBHFMultiarchIncludeDirs;
     else
       MultiarchIncludeDirs = ARMEBMultiarchIncludeDirs;
+    break;
+  case llvm::Triple::m680x0:
+    MultiarchIncludeDirs = M680x0MultiarchIncludeDirs;
     break;
   case llvm::Triple::mips:
     if (getTriple().getSubArch() == llvm::Triple::MipsSubArch_r6)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6029,7 +6029,6 @@ static void handleInterruptAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     handleMipsInterruptAttr(S, D, AL);
     break;
   case llvm::Triple::m680x0:
-  case llvm::Triple::m68k:
     handleM680x0InterruptAttr(S, D, AL);
     break;
   case llvm::Triple::x86:

--- a/llvm/include/llvm/ADT/Triple.h
+++ b/llvm/include/llvm/ADT/Triple.h
@@ -75,7 +75,6 @@ public:
     tcele,          // TCE little endian (http://tce.cs.tut.fi/): tcele
     thumb,          // Thumb (little endian): thumb, thumbv.*
     thumbeb,        // Thumb (big endian): thumbeb
-    m68k,           // M680x0: Motorola 680x0 family
     m680x0,         // M680x0: Motorola 680x0 family
     x86,            // X86: i[3-9]86
     x86_64,         // X86-64: amd64, x86_64

--- a/llvm/lib/Support/Triple.cpp
+++ b/llvm/lib/Support/Triple.cpp
@@ -72,7 +72,6 @@ StringRef Triple::getArchTypeName(ArchType Kind) {
   case wasm32:         return "wasm32";
   case wasm64:         return "wasm64";
   case m680x0:         return "m680x0";
-  case m68k:           return "m68k";
   case x86:            return "i386";
   case x86_64:         return "x86_64";
   case xcore:          return "xcore";
@@ -152,8 +151,7 @@ StringRef Triple::getArchTypePrefix(ArchType Kind) {
   case riscv64:     return "riscv";
 
   case ve:          return "ve";
-  case m68k:
-  case m680x0:     return "m68k";
+  case m680x0:      return "m68k";
   }
 }
 
@@ -325,7 +323,6 @@ Triple::ArchType Triple::getArchTypeForLLVMName(StringRef Name) {
     .Case("renderscript64", renderscript64)
     .Case("ve", ve)
     .Case("m680x0", m680x0)
-    .Case("m68k", m68k)
     .Default(UnknownArch);
 }
 
@@ -425,8 +422,7 @@ static Triple::ArchType parseArch(StringRef ArchName) {
            "mips64r6", "mipsn32r6", Triple::mips64)
     .Cases("mips64el", "mipsn32el", "mipsisa64r6el", "mips64r6el",
            "mipsn32r6el", Triple::mips64el)
-    .Case("m680x0", Triple::m680x0)
-    .Case("m68k", Triple::m68k)
+    .Cases("m680x0", "m68k", Triple::m680x0)
     .Case("r600", Triple::r600)
     .Case("amdgcn", Triple::amdgcn)
     .Case("riscv32", Triple::riscv32)
@@ -672,8 +668,6 @@ static Triple::ObjectFormatType getDefaultFormat(const Triple &T) {
   case Triple::thumb:
   case Triple::x86:
   case Triple::x86_64:
-  case Triple::m680x0:
-  case Triple::m68k:
     if (T.isOSDarwin())
       return Triple::MachO;
     else if (T.isOSWindows())
@@ -696,6 +690,7 @@ static Triple::ObjectFormatType getDefaultFormat(const Triple &T) {
   case Triple::lanai:
   case Triple::le32:
   case Triple::le64:
+  case Triple::m680x0:
   case Triple::mips64:
   case Triple::mips64el:
   case Triple::mips:
@@ -1276,7 +1271,6 @@ static unsigned getArchPointerBitWidth(llvm::Triple::ArchType Arch) {
   case llvm::Triple::xcore:
   case llvm::Triple::wasm32:
   case llvm::Triple::m680x0:
-  case llvm::Triple::m68k:
     return 32;
 
   case llvm::Triple::aarch64:
@@ -1361,7 +1355,6 @@ Triple Triple::get32BitArchVariant() const {
   case Triple::x86:
   case Triple::xcore:
   case Triple::m680x0:
-  case Triple::m68k:
     // Already 32-bit.
     break;
 
@@ -1401,7 +1394,6 @@ Triple Triple::get64BitArchVariant() const {
   case Triple::tcele:
   case Triple::xcore:
   case Triple::m680x0:
-  case Triple::m68k:
     T.setArch(UnknownArch);
     break;
 
@@ -1518,7 +1510,6 @@ Triple Triple::getLittleEndianArchVariant() const {
   case Triple::sparcv9:
   case Triple::systemz:
   case Triple::m680x0:
-  case Triple::m68k:
 
   // ARM is intentionally unsupported here, changing the architecture would
   // drop any arch suffixes.

--- a/llvm/lib/Target/M680x0/TargetInfo/M680x0TargetInfo.cpp
+++ b/llvm/lib/Target/M680x0/TargetInfo/M680x0TargetInfo.cpp
@@ -25,6 +25,4 @@ Target llvm::TheM680x0Target;
 extern "C" void LLVMInitializeM680x0TargetInfo() {
   RegisterTarget<Triple::m680x0, /*HasJIT=*/true> X(
       TheM680x0Target, "m680x0", "Motorola 68000 family", "M680x0");
-  RegisterTarget<Triple::m68k, /*HasJIT=*/true> K(
-      TheM680x0Target, "m68k", "Motorola 68000 family", "M680x0");
 }


### PR DESCRIPTION
This PR fixes the various issues reported in #5 and in #6.

With the changes applied, I can successfully "Hello World" and run it inside an emulator:

```
glaubitz@epyc:/tmp/llvm-build> ./bin/clang -target m68k-linux-gnu ~/hello.c -o hello.m68k
glaubitz@epyc:/tmp/llvm-build> file hello.m68k 
hello.m68k: ELF 32-bit MSB executable, Motorola m68k, 68020, version 1 (SYSV), dynamically linked, interpreter /lib/ld.so.1, for GNU/Linux 3.2.0, not stripped
glaubitz@epyc:/tmp/llvm-build> cp -av hello.m68k /local_scratch/glaubitz/
'hello.m68k' -> '/local_scratch/glaubitz/hello.m68k'
glaubitz@epyc:/tmp/llvm-build> schroot -c sid-m68k-sbuild
glaubitz@epyc:/tmp/llvm-build> uname -a
Linux epyc 5.6.0-2-amd64 #1 SMP Debian 5.6.14-1 (2020-05-23) m68k GNU/Linux
glaubitz@epyc:/tmp/llvm-build> /glaubitz/hello.m68k 
Hello World!
glaubitz@epyc:/tmp/llvm-build>
```